### PR TITLE
adding codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,18 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.inc"
+  - "**.module"
+  - "**.py"
+exclude_paths:
+- config/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-namebench [![Build Status](https://travis-ci.org/mwiora/namebench.svg)](https://travis-ci.org/mwiora/namebench) [![Code Climate](https://codeclimate.com/github/mwiora/namebench/badges/gpa.svg)](https://codeclimate.com/github/facastagnini/namebench)
+namebench [![Build Status](https://travis-ci.org/mwiora/namebench.svg)](https://travis-ci.org/mwiora/namebench) [![Code Climate](https://codeclimate.com/github/mwiora/namebench/badges/gpa.svg)](https://codeclimate.com/github/mwiora/namebench)
 =========
 
 Are you a power-user with 5 minutes to spare? Do you want a faster internet

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-namebench [![Build Status](https://travis-ci.org/mwiora/namebench.svg)](https://travis-ci.org/mwiora/namebench)
+namebench [![Build Status](https://travis-ci.org/mwiora/namebench.svg)](https://travis-ci.org/mwiora/namebench) [![Code Climate](https://codeclimate.com/github/mwiora/namebench/badges/gpa.svg)](https://codeclimate.com/github/facastagnini/namebench)
 =========
 
 Are you a power-user with 5 minutes to spare? Do you want a faster internet


### PR DESCRIPTION
Hi there @mwiora !

I added support for [codeclimate](https://codeclimate.com). They perform static analysis, you can see an example here https://codeclimate.com/github/facastagnini/namebench/

I added the badge to the README and a basic config file, so you will just have to sign up (its free) and add this repo. Additionally it would be great if you can go to the settings and enable the hooks so every pull request will run this tests again.

Best,
Federico